### PR TITLE
feat: Redis adapter using list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,11 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Rider
+bin/
+obj/
+/packages/
+riderModule.iml
+/_ReSharper.Caches/
+.idea/

--- a/Casbin.Adapter.Redis.Benchmark/AdapterBenchmark.cs
+++ b/Casbin.Adapter.Redis.Benchmark/AdapterBenchmark.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+
+namespace Casbin.Adapter.Redis.Benchmark
+{
+    [MemoryDiagnoser]
+    [BenchmarkCategory("Model")]
+    [SimpleJob(RunStrategy.Throughput, targetCount: 10, runtimeMoniker: RuntimeMoniker.Net48)]
+    [SimpleJob(RunStrategy.Throughput, targetCount: 10, runtimeMoniker: RuntimeMoniker.NetCoreApp31, baseline: true)]
+    [SimpleJob(RunStrategy.Throughput, targetCount: 10, runtimeMoniker: RuntimeMoniker.Net50)]
+    [SimpleJob(RunStrategy.Throughput, targetCount: 10, runtimeMoniker: RuntimeMoniker.Net60)]
+    public class ModelBenchmark
+    {
+        private readonly Enforcer _enforcer;
+
+        public ModelBenchmark()
+        {
+            var adapter = new TestHelper.TestRedisAdapter();
+            adapter.Clear();
+            _enforcer = new Enforcer(TestHelper.GetTestFilePath("rbac_model.conf"), adapter);
+        }
+
+        private string NowTestUserName { get; set; }
+        private string NowTestDataName { get; set; }
+
+        [Params(1000, 10000)]
+        public int NowPolicyCount { get; set; }
+
+        [GlobalSetup(Targets = new[] { nameof(AddPolicy), nameof(HasPolicy), nameof(RemovePolicy) })]
+        public void GlobalSetup()
+        {
+            
+            for (int i = 0; i < NowPolicyCount; i++)
+            {
+                _enforcer.AddPolicy($"group{i}", $"obj{i / 10}", "read");
+            }
+            Console.WriteLine($"// Already set {NowPolicyCount} policies.");
+
+            NowTestUserName = $"name{NowPolicyCount / 2 + 1}";
+            NowTestDataName = $"data{NowPolicyCount / 2 + 1}";
+            Console.WriteLine($"// Already set user name to {NowTestUserName}.");
+            Console.WriteLine($"// Already set data name to {NowTestDataName}.");
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("ModelManagement")]
+        public void HasPolicy()
+        {
+            _enforcer.HasPolicy(NowTestUserName, NowTestDataName, "read");
+        }
+
+        [Benchmark]
+        [BenchmarkCategory("ModelManagement")]
+        public void AddPolicy()
+        {
+            _enforcer.AddPolicy(NowTestUserName, NowTestDataName, "read");
+        }
+        
+        [Benchmark]
+        [BenchmarkCategory("ModelManagement")]
+        public void RemovePolicy()
+        {
+            _enforcer.RemovePolicy("group0", "obj0", "read");
+        }
+    }
+}

--- a/Casbin.Adapter.Redis.Benchmark/Casbin.Adapter.Redis.Benchmark.csproj
+++ b/Casbin.Adapter.Redis.Benchmark/Casbin.Adapter.Redis.Benchmark.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Casbin.Adapter.Redis\Casbin.Adapter.Redis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="examples\rbac_model.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="examples\rbac_policy.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="examples\rbac_model.conf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="examples\rbac_policy.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Casbin.Adapter.Redis.Benchmark/Program.cs
+++ b/Casbin.Adapter.Redis.Benchmark/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Casbin.Adapter.Redis.Benchmark
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}

--- a/Casbin.Adapter.Redis.Benchmark/TestHelper.cs
+++ b/Casbin.Adapter.Redis.Benchmark/TestHelper.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using StackExchange.Redis;
+
+namespace Casbin.Adapter.Redis.Benchmark
+{
+    public static class TestHelper
+    {
+        public static string GetTestFilePath(string fileName)
+        {
+            return Path.Combine("examples", fileName);
+        }
+        
+        public class TestRedisAdapter : RedisAdapter
+        {
+            public void Clear()
+            {
+                Database.KeyDelete(Key);
+            }
+        }
+
+    }
+}

--- a/Casbin.Adapter.Redis.Benchmark/examples/rbac_model.conf
+++ b/Casbin.Adapter.Redis.Benchmark/examples/rbac_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/Casbin.Adapter.Redis.Benchmark/examples/rbac_policy.csv
+++ b/Casbin.Adapter.Redis.Benchmark/examples/rbac_policy.csv
@@ -1,0 +1,5 @@
+p, alice, data1, read
+p, bob, data2, write
+p, data2_admin, data2, read
+p, data2_admin, data2, write
+g, alice, data2_admin

--- a/Casbin.Adapter.Redis.UnitTest/AutoTest.cs
+++ b/Casbin.Adapter.Redis.UnitTest/AutoTest.cs
@@ -1,0 +1,387 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Casbin.Adapter.Redis.Entities;
+using Casbin.Adapter.Redis.UnitTest.Fixtures;
+using Casbin.Persist;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Casbin.Adapter.Redis.UnitTest
+{
+    [Collection("Casbin.Adapter.Redis.UnitTest")]
+    public class AdapterTest : TestUtil, IClassFixture<ModelProvideFixture>
+    {
+        private readonly ModelProvideFixture _modelProvideFixture;
+        private static readonly RedisKey _key = "casbin_rules";
+
+        public AdapterTest(ModelProvideFixture modelProvideFixture)
+        {
+            _modelProvideFixture = modelProvideFixture;
+        }
+
+        [Fact]
+        public void TestAdapterAutoSave()
+        {
+            InitPolicy();
+            var adapter = new TestRedisAdapter();
+            var enforcer = new Enforcer(_modelProvideFixture.GetNewRbacModel(), adapter);
+            enforcer.AutoSave = true;
+            
+            #region Load policy test
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+            #endregion
+
+            #region Add policy test
+            enforcer.AddPolicy("alice", "data1", "write");
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data1", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data1", "write")))
+            );
+            #endregion
+            
+            #region Remove poliy test
+            enforcer.RemovePolicy("alice", "data1", "write");
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+
+            enforcer.RemoveFilteredPolicy(0, "data2_admin");
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+            #endregion
+            
+            #region Batch APIs test
+            enforcer.AddPolicies(new []
+            {
+                new List<string>{"alice", "data2", "write"},
+                new List<string>{"bob", "data1", "read"}
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+
+            enforcer.RemovePolicies(new []
+            {
+                new List<string>{"alice", "data1", "read"},
+                new List<string>{"bob", "data2", "write"}
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+            #endregion
+            
+            #region IFilteredAdapter test
+            enforcer.LoadFilteredPolicy(new Filter
+            {
+                P = new List<string>{"bob", "data1", "read"},
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("bob", "data1", "read")
+            ));
+            Assert.True(enforcer.Model.Sections["g"]["g"].Policy.Count is 0);
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+
+            enforcer.LoadFilteredPolicy(new Filter
+            {
+                P = new List<string>{"", "data2", ""},
+                G = new List<string>{"", "data2_admin"},
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data2", "write")
+            ));
+            TestGetGroupingPolicy(enforcer, AsList(
+                AsList("alice", "data2_admin")
+            ));
+            Assert.True(enforcer.Model.Sections["g"]["g"].Policy.Count is 1);
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+            #endregion
+        }
+
+        [Fact]
+        public async Task TestAdapterAutoSaveAsync()
+        {
+            InitPolicy();
+            var adapter = new TestRedisAdapter();
+            var enforcer = new Enforcer(_modelProvideFixture.GetNewRbacModel(), adapter);
+            enforcer.AutoSave = true;
+            
+            #region Load policy test
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+            #endregion
+        
+            #region Add policy test
+            await enforcer.AddPolicyAsync("alice", "data1", "write");
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data1", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data1", "write")))
+            );            
+            #endregion
+        
+            #region Remove policy test
+            await enforcer.RemovePolicyAsync("alice", "data1", "write");
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+        
+            await enforcer.RemoveFilteredPolicyAsync(0, "data2_admin");
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+            #endregion
+        
+            #region Batch APIs test
+            await enforcer.AddPoliciesAsync(new []
+            {
+                new List<string>{"alice", "data2", "write"},
+                new List<string>{"bob", "data1", "read"}
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+        
+            await enforcer.RemovePoliciesAsync(new []
+            {
+                new List<string>{"alice", "data1", "read"},
+                new List<string>{"bob", "data2", "write"}
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")
+            ));
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+            #endregion
+        
+            #region IFilteredAdapter test
+            await enforcer.LoadFilteredPolicyAsync(new Filter
+            {
+                P = new List<string>{"bob", "data1", "read"},
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("bob", "data1", "read")
+            ));
+            Assert.True(enforcer.Model.Sections["g"]["g"].Policy.Count is 0);
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+        
+            await enforcer.LoadFilteredPolicyAsync(new Filter
+            {
+                P = new List<string>{"", "data2", ""},
+                G = new List<string>{"", "data2_admin"},
+            });
+            TestGetPolicy(enforcer, AsList(
+                AsList("alice", "data2", "write")
+            ));
+            TestGetGroupingPolicy(enforcer, AsList(
+                AsList("alice", "data2_admin")
+            ));
+            Assert.True(enforcer.Model.Sections["g"]["g"].Policy.Count is 1);
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data2_admin"),
+                AsList("alice", "data2", "write"),
+                AsList("bob", "data1", "read")))
+            );
+            #endregion
+        }
+
+        [Fact]
+        public void TestSavePolicy()
+        {
+            var adapter = new TestRedisAdapter();
+            adapter.Clear();
+            var e = new Enforcer("examples/rbac_model.conf", "examples/rbac_policy.csv");
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList()))
+            );
+            adapter.SavePolicy(e.Model);
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+        }
+        
+        [Fact]
+        public async Task TestSavePolicyAsync()
+        {
+            var adapter = new TestRedisAdapter();
+            adapter.Clear();
+            var e = new Enforcer("examples/rbac_model.conf", "examples/rbac_policy.csv");
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList()))
+            );
+            await adapter.SavePolicyAsync(e.Model);
+            Assert.True(Array2DEquals(adapter.GetPolicies(), AsList(
+                AsList("alice", "data1", "read"),
+                AsList("bob", "data2", "write"),
+                AsList("data2_admin", "data2", "read"),
+                AsList("data2_admin", "data2", "write"),
+                AsList("alice", "data2_admin")))
+            );
+        }
+
+        private static void InitPolicy()
+        {
+            ConnectionMultiplexer connect = ConnectionMultiplexer.Connect("localhost");
+            IDatabase db = connect.GetDatabase();
+            db.KeyDelete(_key);
+            db.ListRightPush(_key, JsonConvert.SerializeObject(new CasbinRule
+            {
+                PType = "p",
+                V0 = "alice",
+                V1 = "data1",
+                V2 = "read",
+            }));
+            db.ListRightPush(_key, JsonConvert.SerializeObject(new CasbinRule
+            {
+                PType = "p",
+                V0 = "bob",
+                V1 = "data2",
+                V2 = "write",
+            }));
+            db.ListRightPush(_key, JsonConvert.SerializeObject(new CasbinRule
+            {
+                PType = "p",
+                V0 = "data2_admin",
+                V1 = "data2",
+                V2 = "read",
+            }));
+            db.ListRightPush(_key, JsonConvert.SerializeObject(new CasbinRule
+            {
+                PType = "p",
+                V0 = "data2_admin",
+                V1 = "data2",
+                V2 = "write",
+            }));
+            db.ListRightPush(_key, JsonConvert.SerializeObject(new CasbinRule
+            {
+                PType = "g",
+                V0 = "alice",
+                V1 = "data2_admin",
+            }));
+            connect.Close();
+        }
+    }
+}

--- a/Casbin.Adapter.Redis.UnitTest/Casbin.Adapter.Redis.UnitTest.csproj
+++ b/Casbin.Adapter.Redis.UnitTest/Casbin.Adapter.Redis.UnitTest.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Casbin.Adapter.Redis\Casbin.Adapter.Redis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="examples\rbac_policy.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="examples\rbac_model.conf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Casbin.Adapter.Redis.UnitTest/Fixtures/ModelProvideFixture.cs
+++ b/Casbin.Adapter.Redis.UnitTest/Fixtures/ModelProvideFixture.cs
@@ -1,0 +1,14 @@
+﻿using Casbin.Model;
+
+namespace Casbin.Adapter.Redis.UnitTest.Fixtures
+{
+    public class ModelProvideFixture
+    {
+        private readonly string _rbacModelText = System.IO.File.ReadAllText("examples/rbac_model.conf");
+
+        public IModel GetNewRbacModel()
+        {
+            return DefaultModel.CreateFromText(_rbacModelText);
+        }
+    }
+}

--- a/Casbin.Adapter.Redis.UnitTest/SpecialPolicyTest.cs
+++ b/Casbin.Adapter.Redis.UnitTest/SpecialPolicyTest.cs
@@ -1,0 +1,51 @@
+using Casbin.Adapter.Redis.UnitTest.Fixtures;
+using Casbin.Model;
+using Xunit;
+
+namespace Casbin.Adapter.Redis.UnitTest
+{
+    [Collection("Casbin.Adapter.Redis.UnitTest")]
+    public class SpecialPolicyTest :  TestUtil, IClassFixture<ModelProvideFixture>
+    {
+        private readonly ModelProvideFixture _modelProvideFixture;
+
+        public SpecialPolicyTest(ModelProvideFixture modelProvideFixture)
+        {
+            _modelProvideFixture = modelProvideFixture;
+        }
+
+        [Fact]
+        public void TestCommaPolicy()
+        {
+            var adapter = new TestRedisAdapter();
+            adapter.Clear();
+            var enforcer = new Enforcer(DefaultModel.CreateFromText(@"
+[request_definition]
+r = _
+
+[policy_definition]
+p = rule, a1, a2
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = eval(p.rule)
+"), adapter);
+            enforcer.AddFunction("equal", (a1 , a2) => a1 == a2);
+            
+            enforcer.AddPolicy("equal(p.a1, p.a2)", "a1", "a1");
+            Assert.True(enforcer.Enforce("_"));
+            
+            enforcer.LoadPolicy();
+            Assert.True(enforcer.Enforce("_"));
+            
+            enforcer.RemovePolicy("equal(p.a1, p.a2)", "a1", "a1");
+            enforcer.AddPolicy("equal(p.a1, p.a2)", "a1", "a2");
+            Assert.False(enforcer.Enforce("_"));
+            
+            enforcer.LoadPolicy();
+            Assert.False(enforcer.Enforce("_"));
+         }
+    }
+}

--- a/Casbin.Adapter.Redis.UnitTest/TestUtil.cs
+++ b/Casbin.Adapter.Redis.UnitTest/TestUtil.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Casbin.Adapter.Redis.Entities;
+using Casbin.Adapter.Redis.Extensions;
+using Xunit;
+
+namespace Casbin.Adapter.Redis.UnitTest
+{
+    public class TestUtil
+    {
+        public class TestRedisAdapter : RedisAdapter
+        {
+            public void Clear()
+            {
+                Database.KeyDelete(Key);
+            }
+        
+            public List<List<string>> GetPolicies()
+            {
+                var redisValues = Database.ListRange(Key);
+                var casbinRules = redisValues.ToCasbinRules<CasbinRule>();
+                List<List<string>> rules = new List<List<string>>();
+                foreach (var casbinRule in casbinRules)
+                {
+                    List<string> line = new List<string>();
+                    if (casbinRule.V0 != null)
+                    {
+                        line.Add(casbinRule.V0);
+                    }
+                    if (casbinRule.V1 != null)
+                    {
+                        line.Add(casbinRule.V1);
+                    }
+                    if (casbinRule.V2 != null)
+                    {
+                        line.Add(casbinRule.V2);
+                    }
+                    if (casbinRule.V3 != null)
+                    {
+                        line.Add(casbinRule.V3);
+                    }
+                    if (casbinRule.V4 != null)
+                    {
+                        line.Add(casbinRule.V4);
+                    }
+                    if (casbinRule.V5 != null)
+                    {
+                        line.Add(casbinRule.V5);
+                    }
+                    rules.Add(line);
+                }
+                return rules;
+            }
+        }
+
+        internal List<T> AsList<T>(params T[] values)
+        {
+            return values.ToList();
+        }
+        internal List<string> AsList(params string[] values)
+        {
+            return values.ToList();
+        }
+
+        private static bool SetEquals(List<string> a, IEnumerable<string> b)
+        {
+            if (a == null)
+                a = new List<string>();
+            var c = new List<string>();
+            if (b != null)
+                c = b.ToList();
+            if (a.Count != c.Count)
+                return false;
+            a.Sort();
+            c.Sort();
+            for (int index = 0; index < a.Count; ++index)
+            {
+                if (!a[index].Equals(c[index]))
+                    return false;
+            }
+            return true;
+        }
+        
+        private static bool ArrayEquals(List<string> a, IEnumerable<string> b)
+        {
+            if (a == null || b == null)
+                return false;
+            if (a.Count != b.Count())
+                return false;
+            var c = b.ToList();
+            for (int index = 0; index < a.Count; ++index)
+            {
+                if (!a[index].Equals(c[index]))
+                    return false;
+            }
+            return true;
+        }
+        
+        protected static bool Array2DEquals(List<List<string>> a, IEnumerable<IEnumerable<string>> b)
+        {
+            a ??= new List<List<string>>();
+            var c = new List<IEnumerable<string>>();
+            if (b != null)
+                c = b.ToList();
+            if (c.Count == 1 && c[0].Count() == 0)
+            {
+                c.RemoveAt(0);
+            }
+            if (a.Count != c.Count)
+                return false;
+            for (int index = 0; index < a.Count; ++index)
+            {
+                if (!ArrayEquals(a[index], c[index]))
+                    return false;
+            }
+            return true;
+        }
+        
+        internal static void TestEnforce(Enforcer e, String sub, Object obj, String act, Boolean res)
+        { 
+            Assert.Equal(res, e.Enforce(sub, obj, act));
+        }
+
+        internal static void TestEnforceWithoutUsers(Enforcer e, String obj, String act, Boolean res)
+        {
+            Assert.Equal(res, e.Enforce(obj, act));
+        }
+
+        internal static void TestDomainEnforce(Enforcer e, String sub, String dom, String obj, String act, Boolean res)
+        {
+            Assert.Equal(res, e.Enforce(sub, dom, obj, act));
+        }
+
+        internal static void TestGetPolicy(Enforcer e, List<List<String>> res)
+        {
+            IEnumerable<IEnumerable<String>> myRes = e.GetPolicy();
+            Assert.True(Array2DEquals(res, myRes));
+        }
+
+        internal static void TestGetFilteredPolicy(Enforcer e, int fieldIndex, List<List<String>> res, params string[] fieldValues)
+        {
+            IEnumerable<IEnumerable<String>> myRes = e.GetFilteredPolicy(fieldIndex, fieldValues);
+            Assert.True(Array2DEquals(res, myRes));
+        }
+
+        internal static void TestGetGroupingPolicy(Enforcer e, List<List<String>> res)
+        {
+            IEnumerable<IEnumerable<String>> myRes = e.GetGroupingPolicy(); 
+            Assert.Equal(res, myRes);
+        }
+
+        internal static void TestGetFilteredGroupingPolicy(Enforcer e, int fieldIndex, List<List<String>> res, params string[] fieldValues)
+        {
+            IEnumerable<IEnumerable<String>> myRes = e.GetFilteredGroupingPolicy(fieldIndex, fieldValues);
+            Assert.Equal(res, myRes);
+        }
+
+        internal static void TestHasPolicy(Enforcer e, List<String> policy, Boolean res)
+        {
+            Boolean myRes = e.HasPolicy(policy); 
+            Assert.Equal(res, myRes);
+        }
+
+        internal static void TestHasGroupingPolicy(Enforcer e, List<String> policy, Boolean res)
+        {
+            Boolean myRes = e.HasGroupingPolicy(policy);
+            Assert.Equal(res, myRes);
+        }
+
+        internal static void TestGetRoles(Enforcer e, String name, List<String> res)
+        {
+            IEnumerable<String> myRes = e.GetRolesForUser(name);
+            string message = "Roles for " + name + ": " + myRes + ", supposed to be " + res;
+            Assert.True(SetEquals(res, myRes), message);
+        }
+
+        internal static void TestGetUsers(Enforcer e, String name, List<String> res)
+        {
+            IEnumerable<String> myRes = e.GetUsersForRole(name);
+            var message = "Users for " + name + ": " + myRes + ", supposed to be " + res;
+            Assert.True(SetEquals(res, myRes),message);
+        }
+
+        internal static void TestHasRole(Enforcer e, String name, String role, Boolean res)
+        {
+            Boolean myRes = e.HasRoleForUser(name, role);
+            Assert.Equal(res, myRes);
+        }
+
+        internal static void TestGetPermissions(Enforcer e, String name, List<List<String>> res)
+        {
+            IEnumerable<IEnumerable<String>> myRes = e.GetPermissionsForUser(name);
+            var message = "Permissions for " + name + ": " + myRes + ", supposed to be " + res;
+            Assert.True(Array2DEquals(res, myRes));
+        }
+
+        internal static void TestHasPermission(Enforcer e, String name, List<String> permission, Boolean res)
+        {
+            Boolean myRes = e.HasPermissionForUser(name, permission);
+            Assert.Equal(res, myRes);
+        }
+
+        internal static void TestGetRolesInDomain(Enforcer e, String name, String domain, List<String> res)
+        {
+            IEnumerable<String> myRes = e.GetRolesForUserInDomain(name, domain);
+            var message = "Roles for " + name + " under " + domain + ": " + myRes + ", supposed to be " + res;
+            Assert.True(SetEquals(res, myRes), message);
+        }
+
+        internal static void TestGetPermissionsInDomain(Enforcer e, String name, String domain, List<List<String>> res)
+        {
+            IEnumerable<IEnumerable<String>> myRes = e.GetPermissionsForUserInDomain(name, domain);
+            Assert.True(Array2DEquals(res, myRes), "Permissions for " + name + " under " + domain + ": " + myRes + ", supposed to be " + res); 
+        }
+    }
+}

--- a/Casbin.Adapter.Redis.UnitTest/examples/rbac_model.conf
+++ b/Casbin.Adapter.Redis.UnitTest/examples/rbac_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act

--- a/Casbin.Adapter.Redis.UnitTest/examples/rbac_policy.csv
+++ b/Casbin.Adapter.Redis.UnitTest/examples/rbac_policy.csv
@@ -1,0 +1,5 @@
+p, alice, data1, read
+p, bob, data2, write
+p, data2_admin, data2, read
+p, data2_admin, data2, write
+g, alice, data2_admin

--- a/Casbin.Adapter.Redis/Casbin.Adapter.Redis.csproj
+++ b/Casbin.Adapter.Redis/Casbin.Adapter.Redis.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <AssemblyName>Casbin.Adapter.Redis</AssemblyName>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Casbin.NET.Adapter.Redis</PackageId>
+    <PackageIcon>casbin.png</PackageIcon>
+    <Authors>Casbin.NET</Authors>
+    <RepositoryType>GIT</RepositoryType>
+    <RepositoryUrl>https://github.com/casbin-net/redis-adapter</RepositoryUrl>
+    <Copyright>Apache License 2.0</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/casbin-net/redis-adapter</PackageProjectUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Casbin.NET" Version="2.0.0-preview.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.6.48" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="casbin.png" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
+</Project>

--- a/Casbin.Adapter.Redis/Entities/CasbinRule.cs
+++ b/Casbin.Adapter.Redis/Entities/CasbinRule.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Casbin.Adapter.Redis.Entities
+{
+    public class CasbinRule : ICasbinRule
+    {
+        public string PType { get; set; }
+        public string V0 { get; set; }
+        public string V1 { get; set; }
+        public string V2 { get; set; }
+        public string V3 { get; set; }
+        public string V4 { get; set; }
+        public string V5 { get; set; }
+    }
+}

--- a/Casbin.Adapter.Redis/Extensions/CasbinModelExtension.cs
+++ b/Casbin.Adapter.Redis/Extensions/CasbinModelExtension.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Casbin.Model;
+using Casbin.Persist;
+
+namespace Casbin.Adapter.Redis.Extensions
+{
+    public static class CasbinModelExtension
+    {
+        internal static void LoadPolicyFromCasbinRules<TCasbinRule>(this IPolicyStore casbinModel, IEnumerable<TCasbinRule> rules) 
+            where TCasbinRule : class, ICasbinRule
+        {
+            foreach (var rule in rules)
+            {
+                casbinModel.TryLoadPolicyLine(rule.ToList());
+            }
+        }
+    }
+}

--- a/Casbin.Adapter.Redis/Extensions/CasbinRuleExtenstion.cs
+++ b/Casbin.Adapter.Redis/Extensions/CasbinRuleExtenstion.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Linq;
+using Casbin.Model;
+
+namespace Casbin.Adapter.Redis.Extensions
+{
+    public static class CasbinRuleExtenstion
+    {
+        internal static List<string> ToList(this ICasbinRule rule)
+        {
+            var list = new List<string> {rule.PType};
+            if (string.IsNullOrEmpty(rule.V0) is false)
+            {
+                list.Add(rule.V0);
+            }
+            if (string.IsNullOrEmpty(rule.V1) is false)
+            {
+                list.Add(rule.V1);
+            }
+            if (string.IsNullOrEmpty(rule.V2) is false)
+            {
+                list.Add(rule.V2);
+            }
+            if (string.IsNullOrEmpty(rule.V3) is false)
+            {
+                list.Add(rule.V3);
+            }
+            if (string.IsNullOrEmpty(rule.V4) is false)
+            {
+                list.Add(rule.V4);
+            }
+            if (string.IsNullOrEmpty(rule.V5) is false)
+            {
+                list.Add(rule.V5);
+            }
+            return list;
+        }
+        
+        internal static void ReadPolicyFromCasbinModel<TCasbinRule>(this ICollection<TCasbinRule> casbinRules, IPolicyStore casbinModel) 
+            where TCasbinRule : class,ICasbinRule, new()
+        {
+            if (casbinModel.Sections.ContainsKey("p"))
+            {
+                foreach (var assertionKeyValuePair in casbinModel.Sections["p"])
+                {
+                    string policyType = assertionKeyValuePair.Key;
+                    Assertion assertion = assertionKeyValuePair.Value;
+                    foreach (TCasbinRule rule in assertion.Policy
+                                 .Select(ruleStrings => 
+                                     Parse<TCasbinRule>(policyType, ruleStrings)))
+                    {
+                        casbinRules.Add(rule);
+                    }
+                }
+            }
+            if (casbinModel.Sections.ContainsKey("g"))
+            {
+                foreach (var assertionKeyValuePair in casbinModel.Sections["g"])
+                {
+                    string policyType = assertionKeyValuePair.Key;
+                    Assertion assertion = assertionKeyValuePair.Value;
+                    foreach (TCasbinRule rule in assertion.Policy
+                                 .Select(ruleStrings => 
+                                     Parse<TCasbinRule>(policyType, ruleStrings)))
+                    {
+                        casbinRules.Add(rule);
+                    }
+                }
+            }
+        }
+
+        internal static TCasbinRule Parse<TCasbinRule>(string policyType, IEnumerable<string> ruleStrings)
+            where TCasbinRule : ICasbinRule, new()
+        {
+            var rule = new TCasbinRule{PType = policyType};
+            var strings = ruleStrings.ToList();
+            int count = strings.Count;
+
+            if (count > 0)
+            {
+                rule.V0 = strings[0];
+            }
+
+            if (count > 1)
+            {
+                rule.V1 = strings[1];
+            }
+
+            if (count > 2)
+            {
+                rule.V2 = strings[2];
+            }
+
+            if (count > 3)
+            {
+                rule.V3 = strings[3];
+            }
+
+            if (count > 4)
+            {
+                rule.V4 = strings[4];
+            }
+
+            if (count > 5)
+            {
+                rule.V5 = strings[5];
+            }
+
+            return rule;
+        }
+
+    }
+}

--- a/Casbin.Adapter.Redis/Extensions/RedisValuesExtension.cs
+++ b/Casbin.Adapter.Redis/Extensions/RedisValuesExtension.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Casbin.Persist;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace Casbin.Adapter.Redis.Extensions
+{
+    public static class RedisValuesExtension
+    {
+        public static IEnumerable<TCasbinRule> ToCasbinRules<TCasbinRule>(this RedisValue[] redisValues)
+            where TCasbinRule : ICasbinRule
+        {
+            ICollection<TCasbinRule> casbinRules = new List<TCasbinRule>();
+            foreach (var redisValue in redisValues)
+            {
+                casbinRules.Add(JsonConvert.DeserializeObject<TCasbinRule>(redisValue.ToString()));
+            }
+            return casbinRules;
+        }
+        
+        internal static IEnumerable<TCasbinRule> ApplyQueryFilter<TCasbinRule>(this RedisValue[] redisValues, 
+            string policyType , int fieldIndex, IEnumerable<string> fieldValues)
+            where TCasbinRule : ICasbinRule
+        {
+            if (fieldIndex > 5)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fieldIndex));
+            }
+            
+            ICollection<TCasbinRule> casbinRulesCollection = new List<TCasbinRule>();
+            foreach (var redisValue in redisValues)
+            {
+                casbinRulesCollection.Add(JsonConvert.DeserializeObject<TCasbinRule>(redisValue));
+            }
+            IEnumerable<TCasbinRule> casbinRules = casbinRulesCollection;
+            
+            var fieldValuesList = fieldValues as IList<string> ?? fieldValues.ToArray();
+            int fieldValueCount = fieldValuesList.Count;
+
+            if (fieldValueCount is 0)
+            {
+                return casbinRules;
+            }
+
+            int lastIndex = fieldIndex + fieldValueCount - 1;
+
+            if (lastIndex > 5)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lastIndex));
+            }
+
+            casbinRules = casbinRules.Where(p => string.Equals(p.PType, policyType));
+
+            if (fieldIndex is 0 && lastIndex >= 0)
+            {
+                string field = fieldValuesList[fieldIndex];
+                if (string.IsNullOrWhiteSpace(field) is false)
+                {
+                    casbinRules = casbinRules.Where(p => p.V0 == field);
+                }
+            }
+
+            if (fieldIndex <= 1 && lastIndex >= 1)
+            {
+                string field = fieldValuesList[1 - fieldIndex];
+                if (string.IsNullOrWhiteSpace(field) is false)
+                {
+                    casbinRules = casbinRules.Where(p => p.V1 == field);
+                }
+            }
+
+            if (fieldIndex <= 2 && lastIndex >= 2)
+            {
+                string field = fieldValuesList[2 - fieldIndex];
+                if (string.IsNullOrWhiteSpace(field) is false)
+                {
+                    casbinRules = casbinRules.Where(p => p.V2 == field);
+                }
+            }
+
+            if (fieldIndex <= 3 && lastIndex >= 3)
+            {
+                string field = fieldValuesList[3 - fieldIndex];
+                if (string.IsNullOrWhiteSpace(field) is false)
+                {
+                    casbinRules = casbinRules.Where(p => p.V3 == field);
+                }
+            }
+
+            if (fieldIndex <= 4 && lastIndex >= 4)
+            {
+                string field = fieldValuesList[4 - fieldIndex];
+                if (string.IsNullOrWhiteSpace(field) is false)
+                {
+                    casbinRules = casbinRules.Where(p => p.V4 == field);
+                }
+            }
+
+            if (lastIndex is 5) // and fieldIndex <= 5
+            {
+                string field = fieldValuesList[5 - fieldIndex];
+                if (string.IsNullOrWhiteSpace(field) is false)
+                {
+                    casbinRules = casbinRules.Where(p => p.V5 == field);
+                }
+            }
+
+            return casbinRules;
+        }
+        
+        internal static IEnumerable<TCasbinRule> ApplyQueryFilter<TCasbinRule>(this RedisValue[] redisValues, Filter filter)
+            where TCasbinRule : ICasbinRule
+        {
+            var casbinRules = redisValues.ToCasbinRules<TCasbinRule>();
+            
+            if (filter is null)
+            {
+                return casbinRules;
+            }
+
+            if (filter.P is null && filter.G is null)
+            {
+                return casbinRules;
+            }
+
+            if (filter.P is not null && filter.G is not null)
+            {
+                var queryP = redisValues.ApplyQueryFilter<TCasbinRule>(PermConstants.DefaultPolicyType, 0, filter.P);
+                var queryG = redisValues.ApplyQueryFilter<TCasbinRule>(PermConstants.DefaultGroupingPolicyType, 0, filter.G);
+                return queryP.Union(queryG);
+            }
+
+            if (filter.P is not null)
+            {
+                casbinRules = redisValues.ApplyQueryFilter<TCasbinRule>(PermConstants.DefaultPolicyType, 0, filter.P);
+            }
+
+            if (filter.G is not null)
+            {
+                casbinRules = redisValues.ApplyQueryFilter<TCasbinRule>(PermConstants.DefaultGroupingPolicyType, 0, filter.G);
+            }
+
+            return casbinRules;
+        }
+
+    }
+}

--- a/Casbin.Adapter.Redis/ICasbinRule.cs
+++ b/Casbin.Adapter.Redis/ICasbinRule.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Casbin.Adapter.Redis
+{
+    // public interface ICasbinRule<TKey> : ICasbinRule where TKey : IEquatable<TKey>
+    // {
+    //     public TKey Id { get; set; }
+    // }
+
+    public interface ICasbinRule
+    {
+        public string PType { get; set; }
+        public string V0 { get; set; }
+        public string V1 { get; set; }
+        public string V2 { get; set; }
+        public string V3 { get; set; }
+        public string V4 { get; set; }
+        public string V5 { get; set; }
+    }
+}

--- a/Casbin.Adapter.Redis/IRedisAdapterOptions.cs
+++ b/Casbin.Adapter.Redis/IRedisAdapterOptions.cs
@@ -1,0 +1,9 @@
+namespace Casbin.Adapter.Redis
+{
+    public interface IRedisAdapterOptions
+    {
+        public string Address { get; set; }
+        public string Password { get; set; }
+        public string Key { get; set; }
+    }
+}

--- a/Casbin.Adapter.Redis/RedisAdapter.cs
+++ b/Casbin.Adapter.Redis/RedisAdapter.cs
@@ -1,0 +1,342 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Casbin.Adapter.Redis.Entities;
+using Casbin.Adapter.Redis.Extensions;
+using Casbin.Model;
+using Casbin.Persist;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace Casbin.Adapter.Redis
+{
+    public class RedisAdapter : RedisAdapter<CasbinRule>
+    {
+        public RedisAdapter() : base()
+        {
+        }
+    }
+
+    public class RedisAdapter<TCasbinRule> : IAdapter, IFilteredAdapter
+        where TCasbinRule : class, ICasbinRule, new()
+    {
+        protected ConnectionMultiplexer Connection { get; }
+        protected IDatabase Database { get; }
+        protected IRedisAdapterOptions RedisAdapterOptions { get; }
+        protected RedisKey Key { get; } = "casbin_rules";
+        
+        public RedisAdapter()
+        {
+            IRedisAdapterOptions adapterOptions = new RedisAdapterOptions();
+            adapterOptions.Address = "localhost";
+            adapterOptions.Password = null;
+            adapterOptions.Key = Key;
+            
+            RedisAdapterOptions = adapterOptions;
+            Connection = ConnectionMultiplexer.Connect("localhost");
+            Database = Connection.GetDatabase();
+        }
+        
+        public RedisAdapter(IRedisAdapterOptions redisAdapterOptions)
+        {
+            RedisAdapterOptions = redisAdapterOptions;
+            if (redisAdapterOptions.Key != null)
+            {
+                Key = redisAdapterOptions.Key;
+            }
+            else
+            {
+                redisAdapterOptions.Key = Key;
+            }
+            Connection = ConnectionMultiplexer.Connect($"{redisAdapterOptions.Address},password={redisAdapterOptions.Password}");
+            Database = Connection.GetDatabase();
+        }
+
+        #region virtual method
+        protected virtual IEnumerable<TCasbinRule> OnLoadPolicy(IPolicyStore model, IEnumerable<TCasbinRule> casbinRules)
+        {
+            return casbinRules;
+        }
+        
+        protected virtual IEnumerable<TCasbinRule> OnSavePolicy(IPolicyStore model, IEnumerable<TCasbinRule> casbinRules)
+        {
+            return casbinRules;
+        }
+        
+        protected virtual TCasbinRule OnAddPolicy(string section, string policyType, IEnumerable<string> rule, TCasbinRule casbinRule)
+        {
+            return casbinRule;
+        }
+
+        protected virtual IEnumerable<TCasbinRule> OnAddPolicies(string section, string policyType,
+            IEnumerable<IEnumerable<string>> rules, IEnumerable<TCasbinRule> casbinRules)
+        {
+            return casbinRules;
+        }
+
+        protected virtual IEnumerable<TCasbinRule> OnRemoveFilteredPolicy(string section, string policyType, 
+            int fieldIndex, string[] fieldValues, IEnumerable<TCasbinRule> casbinRules)
+        {
+            return casbinRules;
+        }
+        
+        #endregion
+        
+        #region Load policy
+        
+        public virtual void LoadPolicy(IPolicyStore model)
+        {
+            var redisValues = Database.ListRange(Key);
+            var casbinRules = redisValues.ToCasbinRules<TCasbinRule>();
+            casbinRules = OnLoadPolicy(model, casbinRules);
+            model.LoadPolicyFromCasbinRules(casbinRules);
+            IsFiltered = false;
+        }
+        
+        public virtual async Task LoadPolicyAsync(IPolicyStore model)
+        {
+            var redisValues = await Database.ListRangeAsync(Key);
+            var casbinRules = redisValues.ToCasbinRules<TCasbinRule>();
+            casbinRules = OnLoadPolicy(model, casbinRules);
+            model.LoadPolicyFromCasbinRules(casbinRules);
+            IsFiltered = false;
+        }
+        
+        #endregion
+        
+        #region Save policy
+        
+        public virtual void SavePolicy(IPolicyStore model)
+        {
+            var casbinRules = new List<TCasbinRule>();
+            casbinRules.ReadPolicyFromCasbinModel(model);
+
+            if (casbinRules.Count is 0)
+            {
+                return;
+            }
+
+            var saveRules = OnSavePolicy(model, casbinRules);
+
+            Database.KeyDelete(Key);
+            foreach (var saveRule in saveRules)
+            {
+                Database.ListRightPush(Key, JsonConvert.SerializeObject(saveRule));
+            }
+        }
+        
+        public virtual async Task SavePolicyAsync(IPolicyStore model)
+        {
+            var casbinRules = new List<TCasbinRule>();
+            casbinRules.ReadPolicyFromCasbinModel(model);
+
+            if (casbinRules.Count is 0)
+            {
+                return;
+            }
+
+            var saveRules = OnSavePolicy(model, casbinRules);
+
+            await Database.KeyDeleteAsync(Key);
+            foreach (var saveRule in saveRules)
+            {
+                await Database.ListRightPushAsync(Key, JsonConvert.SerializeObject(saveRule));
+            }
+        }
+        
+        #endregion
+        
+        #region Add policy
+        
+        public virtual void AddPolicy(string section, string policyType, IEnumerable<string> rule)
+        {
+            if (rule is null || rule.Count() is 0)
+            {
+                return;
+            }
+
+            var casbinRule = CasbinRuleExtenstion.Parse<TCasbinRule>(policyType, rule);
+            casbinRule = OnAddPolicy(section, policyType, rule, casbinRule);
+            Database.ListRightPush(Key, JsonConvert.SerializeObject(casbinRule));
+        }
+        
+        public virtual async Task AddPolicyAsync(string section, string policyType, IEnumerable<string> rule)
+        {
+            if (rule is null || rule.Count() is 0)
+            {
+                return;
+            }
+
+            var casbinRule = CasbinRuleExtenstion.Parse<TCasbinRule>(policyType, rule);
+            casbinRule = OnAddPolicy(section, policyType, rule, casbinRule);
+            await Database.ListRightPushAsync(Key, JsonConvert.SerializeObject(casbinRule));
+        }
+        
+        public virtual void AddPolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
+        {
+            if (rules is null)
+            {
+                return;
+            }
+
+            var rulesArray = rules as IList<string>[] ?? rules.ToArray();
+            if (rulesArray.Length is 0)
+            {
+                return;
+            }
+
+            var casbinRules = rulesArray.Select(r => 
+                CasbinRuleExtenstion.Parse<TCasbinRule>(policyType, r.ToList()));
+            casbinRules = OnAddPolicies(section, policyType, rulesArray, casbinRules);
+            foreach (var casbinRule in casbinRules)
+            {
+                Database.ListRightPush(Key, JsonConvert.SerializeObject(casbinRule));
+            }
+        }
+        
+        public virtual async Task AddPoliciesAsync(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
+        {
+            if (rules is null)
+            {
+                return;
+            }
+
+            var rulesArray = rules as IList<string>[] ?? rules.ToArray();
+            if (rulesArray.Length is 0)
+            {
+                return;
+            }
+
+            var casbinRules = rulesArray.Select(r => 
+                CasbinRuleExtenstion.Parse<TCasbinRule>(policyType, r.ToList()));
+            casbinRules = OnAddPolicies(section, policyType, rulesArray, casbinRules);
+            foreach (var casbinRule in casbinRules)
+            {
+                await Database.ListRightPushAsync(Key, JsonConvert.SerializeObject(casbinRule));
+            }
+        }
+        
+        #endregion
+        
+        #region Remove policy
+
+        public virtual void RemovePolicy(string section, string policyType, IEnumerable<string> rule)
+        {
+            if (rule is null || rule.Count() is 0)
+            {
+                return;
+            }
+
+            RemoveFilteredPolicy(section, policyType, 0, rule as string[] ?? rule.ToArray());
+        }
+
+        public virtual async Task RemovePolicyAsync(string section, string policyType, IEnumerable<string> rule)
+        {
+            if (rule is null || rule.Count() is 0)
+            {
+                return;
+            }
+
+            await RemoveFilteredPolicyAsync(section, policyType, 0, rule as string[] ?? rule.ToArray());        
+        }
+        
+        public virtual void RemoveFilteredPolicy(string section, string policyType, int fieldIndex, params string[] fieldValues)
+        {
+            if (fieldValues is null || fieldValues.Length is 0)
+            {
+                return;
+            }
+
+            var redisRules = Database.ListRange(Key);
+            var casbinRules = redisRules.ApplyQueryFilter<TCasbinRule>(policyType, fieldIndex, fieldValues);
+            casbinRules = OnRemoveFilteredPolicy(section, policyType, fieldIndex, fieldValues, casbinRules);
+            
+            foreach (var casbinRule in casbinRules)
+            {
+                Database.ListRemove(Key, JsonConvert.SerializeObject(casbinRule));
+            }
+        }
+        
+        public virtual async Task RemoveFilteredPolicyAsync(string section, string policyType, int fieldIndex, params string[] fieldValues)
+        {
+            if (fieldValues is null || fieldValues.Length is 0)
+            {
+                return;
+            }
+
+            var redisRules = await Database.ListRangeAsync(Key);
+            var casbinRules = redisRules.ApplyQueryFilter<TCasbinRule>(policyType, fieldIndex, fieldValues);
+            casbinRules = OnRemoveFilteredPolicy(section, policyType, fieldIndex, fieldValues, casbinRules);
+            
+            foreach (var casbinRule in casbinRules)
+            {
+                await Database.ListRemoveAsync(Key, JsonConvert.SerializeObject(casbinRule));
+            }        
+        }
+
+
+        public virtual void RemovePolicies(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
+        {
+            if (rules is null)
+            {
+                return;
+            }
+
+            var rulesArray = rules as IList<string>[] ?? rules.ToArray();
+            if (rulesArray.Length is 0)
+            {
+                return;
+            }
+
+            foreach (var rule in rulesArray)
+            {
+                RemoveFilteredPolicy(section, policyType, 0, rule as string[] ?? rule.ToArray());
+            }
+        }
+
+        public virtual async Task RemovePoliciesAsync(string section, string policyType, IEnumerable<IEnumerable<string>> rules)
+        {
+            if (rules is null)
+            {
+                return;
+            }
+
+            var rulesArray = rules as IList<string>[] ?? rules.ToArray();
+            if (rulesArray.Length is 0)
+            {
+                return;
+            }
+
+            foreach (var rule in rulesArray)
+            {
+                await RemoveFilteredPolicyAsync(section, policyType, 0, rule as string[] ?? rule.ToArray());
+            }
+        }
+
+        #endregion
+
+        #region IFilteredAdapter
+
+        public bool IsFiltered { get; private set; }
+
+        public void LoadFilteredPolicy(IPolicyStore model, Filter filter)
+        {
+            var redisValues = Database.ListRange(Key);
+            var casbinRules = redisValues.ApplyQueryFilter<TCasbinRule>(filter);
+            casbinRules = OnLoadPolicy(model, casbinRules);
+            model.LoadPolicyFromCasbinRules(casbinRules);
+            IsFiltered = true;
+        }
+
+        public async Task LoadFilteredPolicyAsync(IPolicyStore model, Filter filter)
+        {
+            var redisValues = await Database.ListRangeAsync(Key);
+            var casbinRules = redisValues.ApplyQueryFilter<TCasbinRule>(filter);
+            casbinRules = OnLoadPolicy(model, casbinRules);
+            model.LoadPolicyFromCasbinRules(casbinRules);
+            IsFiltered = true;
+        }
+
+        #endregion
+    }
+}

--- a/Casbin.Adapter.Redis/RedisAdapterOptions.cs
+++ b/Casbin.Adapter.Redis/RedisAdapterOptions.cs
@@ -1,0 +1,9 @@
+namespace Casbin.Adapter.Redis
+{
+    public class RedisAdapterOptions : IRedisAdapterOptions
+    {
+        public string Address { get; set; }
+        public string Password { get; set; }
+        public string Key { get; set; }
+    }
+}

--- a/Redis-Adapter.sln
+++ b/Redis-Adapter.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Casbin.Adapter.Redis", "Casbin.Adapter.Redis\Casbin.Adapter.Redis.csproj", "{26B6A0B7-7D0A-47D5-8562-C7D4690F2609}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Casbin.Adapter.Redis.UnitTest", "Casbin.Adapter.Redis.UnitTest\Casbin.Adapter.Redis.UnitTest.csproj", "{9241E981-DDBF-444E-836A-3EE6C2DB59DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Casbin.Adapter.Redis.Benchmark", "Casbin.Adapter.Redis.Benchmark\Casbin.Adapter.Redis.Benchmark.csproj", "{D4B73EFF-C6F4-483F-AD3D-9C9DCFDA7D38}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{26B6A0B7-7D0A-47D5-8562-C7D4690F2609}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26B6A0B7-7D0A-47D5-8562-C7D4690F2609}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26B6A0B7-7D0A-47D5-8562-C7D4690F2609}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26B6A0B7-7D0A-47D5-8562-C7D4690F2609}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9241E981-DDBF-444E-836A-3EE6C2DB59DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9241E981-DDBF-444E-836A-3EE6C2DB59DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9241E981-DDBF-444E-836A-3EE6C2DB59DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9241E981-DDBF-444E-836A-3EE6C2DB59DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4B73EFF-C6F4-483F-AD3D-9C9DCFDA7D38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4B73EFF-C6F4-483F-AD3D-9C9DCFDA7D38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4B73EFF-C6F4-483F-AD3D-9C9DCFDA7D38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4B73EFF-C6F4-483F-AD3D-9C9DCFDA7D38}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
feat: Redis adapter using list

The ordered Redis data structures suitable as storage are `zset` and `list`. `zset` ensures uniqueness of policies, but requires passing in a value (e.g. `DateTime.UtcNow.Ticks`) as the sorting reference. `list` does not require an additional value, but deleting policies might be cumbersome. To compare their advantages and disadvantages, I implemented 2 versions of each, corresponding to the `zset` and `list` branches of my own repository. On my computer, the benchmarks against the functions `HasPolicy`, `AddPolicy`, and `RemovePolicy` shows that there is little difference between the two when the number of policies is 10,000. So I choose to merge `list` branch. If `zset` is considered as the better implemention, I will open another PR.